### PR TITLE
ctargs variable misspelled

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -39,7 +39,7 @@ reload_consul_template() {
 
 	consul-template -log-level ${CONSUL_LOGLEVEL} \
 		-config /consul-template/config.d \
-	${ctvars} &
+	${ctargs} &
 	ctpid=$!
 }
 


### PR DESCRIPTION
Fix for https://github.com/CiscoCloud/nginx-consul/issues/13 where system variables are not handled